### PR TITLE
Add a method that returns BFTask

### DIFF
--- a/PFCloud+Cache.h
+++ b/PFCloud+Cache.h
@@ -7,8 +7,13 @@
 //
 
 #import <Parse/Parse.h>
+#import <Parse/PFConstants.h>
+
+@class BFTask;
 
 @interface PFCloud (Cache)
+
++ (BFTask *)callFunctionInBackground:(NSString *)function withParameters:(NSDictionary *)parameters cachePolicy:(PFCachePolicy)cachePolicy;
 
 /*
  Calls the given cloud function with the parameters provided asynchronously and runs the callback when it is done.

--- a/PFCloud+Cache.m
+++ b/PFCloud+Cache.m
@@ -9,10 +9,25 @@
 #import "PFCloud+Cache.h"
 #import "TMCache.h"
 #import "NSData+MD5Digest.h"
+#import "BFTask.h"
+#import "BFTaskCompletionSource.h"
 
 @implementation PFCloud (Cache)
 
 #pragma mark - Public
+
++ (BFTask *) callFunctionInBackground:(NSString*)function withParameters:(NSDictionary*)parameters cachePolicy:(PFCachePolicy)cachePolicy {
+    NSAssert(cachePolicy != kPFCachePolicyCacheThenNetwork, @"Can not use BFTask with kPFCachePolicyCacheThenNetwork because the callback my be executed more than once. Use a signature that accepts a block instead");
+    BFTaskCompletionSource *tcs = [BFTaskCompletionSource taskCompletionSource];
+    [self callFunctionInBackground:function withParameters:parameters cachePolicy:cachePolicy block:^(id object, NSError *error) {
+        if(error)
+            [tcs setError:error];
+        else
+            [tcs setResult:object];
+    }];
+    return tcs.task;
+}
+
 
 + (void)callFunctionInBackground:(NSString*)function withParameters:(NSDictionary*)parameters cachePolicy:(PFCachePolicy)cachePolicy block:(PFIdResultBlock)block
 {


### PR DESCRIPTION
I recently started using the signatures available in the Parse API that return BFTasks which are a really good way to chain together asynchronous logic. I use your very helpful library in a few of my apps, and it was getting awkward to keep having to switch between BFTasks and block callbacks, so I added a signature that works with BFTask and make the library consistent with other Parse APIs. 

One Note: since a BFTask can only be completed once, this signature will fail an assertion if you try to use cache-then-network policy which would try to complete the task twice. 
